### PR TITLE
Change uri imports to use blobUrl

### DIFF
--- a/packages/quartz/index.js
+++ b/packages/quartz/index.js
@@ -222,13 +222,15 @@ export default async function quartz(
   const globalStoreID = "QZ_" + generateRandomString(7);
   globalThis[globalStoreID] = quartzStore;
 
-  const mod = await import(
-    `data:text/javascript;charset=UTF-8,${encodeURIComponent(
-      `const $$$QUARTZ_STORE = globalThis["${globalStoreID}"];const $$$QUARTZ_DYNAMIC_RESOLVE = $$$QUARTZ_STORE.dynamicResolver;` +
-        generatedImports +
-        code
-    )}`
-  );
+  const fullCode = `
+    const $$$QUARTZ_STORE = globalThis["${globalStoreID}"];
+    const $$$QUARTZ_DYNAMIC_RESOLVE = $$$QUARTZ_STORE.dynamicResolver;
+    ${generatedImports}
+    ${code}
+  `;
+  
+  const blobURL = URL.createObjectURL(new Blob([fullCode], { type: 'text/javascript' }));
+  const mod = await import(blobURL);
 
   delete globalThis[globalStoreID];
 


### PR DESCRIPTION
Importing using `data:text/javascript;charset=UTF-8,${encodeURIComponent(...` causes devTools to crash frequently due to OOM and general stability/performance issues.

Swapping for a blobUrl works flawlessly from my testing and has none of those issues.