### PR TITLE
Add dynamicResolve types

### DIFF
--- a/packages/quartz/index.d.ts
+++ b/packages/quartz/index.d.ts
@@ -16,6 +16,12 @@ export type QuartzPlugin = {
 		name: string,
 		moduleId: string
 	}): MaybePromise<string | undefined>
+
+	dynamicResolve?(ctx: {
+		config: QuartzConfig,
+		name: string,
+		moduleId: string
+	}): Promise<object>
 }
 
 declare const _default: (code: string, config: QuartzConfig, moduleId?: string) => Promise<object>;


### PR DESCRIPTION
Add typing's for `QuartzPlugin.dynamicResolve` let me know if I've missed anything, based on observed behavior should be accurate.